### PR TITLE
Add Youngstown State University Web Developer job listing

### DIFF
--- a/data/jobs.ts
+++ b/data/jobs.ts
@@ -10,6 +10,15 @@ export type Job = {
 };
 export const jobs: Job[] = [
   {
+    title: "Web Developer",
+    company: "Youngstown State University",
+    desc: "Plans, designs, and develops web assets, templates, and digital content within university CMS standards. Builds and maintains front-end experiences in Drupal using HTML5, CSS3, JavaScript/jQuery, and responsive design best practices while supporting accessibility (ADA) compliance, quality control, and cross-department web projects.",
+    location: "Youngstown, OH",
+    salary: "$35,780.00 - $42,050.00 Annually",
+    listing: "https://www.schooljobs.com/careers/ysu",
+    date: "2026-02-11",
+  },
+  {
     title: "Data Scientist",
     company: "BlastPoint",
     desc: "Lead client-facing machine learning projects, building reproducible models, improving internal data products, and collaborating with customers to deliver predictive insights at scale.",


### PR DESCRIPTION
### Motivation
- Add a current Web Developer opening from Youngstown State University to the site’s jobs dataset so it appears on the Jobs page alongside other local listings.

### Description
- Inserted a new `Job` entry at the top of `data/jobs.ts` with `title`, `company`, `desc`, `location`, `salary`, `listing`, and `date` fields for the YSU Web Developer position.

### Testing
- Ran `npm run lint` and it completed successfully with no new errors related to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6e1f530c832a9385fd6c4eea355d)