### PR TITLE
Add BlastPoint VP of Engineering job listing

### DIFF
--- a/data/jobs.ts
+++ b/data/jobs.ts
@@ -10,6 +10,15 @@ export type Job = {
 };
 export const jobs: Job[] = [
   {
+    title: "VP of Engineering",
+    company: "BlastPoint",
+    desc: "Lead and scale BlastPoint’s engineering organization as a key member of the leadership team, owning delivery, technical strategy, and team growth. The role partners with executive and product leadership to set roadmap priorities, improve engineering velocity, and ensure reliable, scalable platform architecture. Candidates should bring deep startup engineering leadership experience, strong Python and AWS expertise, and a track record of building high-performing teams in data-intensive SaaS environments.",
+    location: "Pittsburgh, PA",
+    salary: "Competitive Salary",
+    listing: "https://job-boards.greenhouse.io/blastpoint/jobs/5064257007",
+    date: "2026-02-27",
+  },
+  {
     title: "Senior Full Stack Engineer",
     company: "PDMI",
     desc: "Design and develop API-first backend services in NodeJS while building modern, responsive React user interfaces. The role supports MSSQL-backed, event-driven architectures, drives system scalability and reliability improvements, reduces technical debt, and contributes clean, testable, well-documented code in a collaborative environment. Candidates should bring 6+ years of software development experience, including strong NodeJS, React, and relational database expertise, with AWS experience preferred.",


### PR DESCRIPTION
### Motivation
- Add the VP of Engineering opening from BlastPoint to the site job board so the community can discover and apply to the role listed in Slack.
- Populate the jobs dataset with up-to-date information pulled from the Greenhouse posting to keep the job board current.

### Description
- Inserted a new job entry at the top of `data/jobs.ts` with fields `title`, `company`, `desc`, `location`, `salary`, `listing`, and `date` populated from the BlastPoint Greenhouse posting (`https://job-boards.greenhouse.io/blastpoint/jobs/5064257007`).
- The description is a condensed summary of the live posting emphasizing leadership, Python and AWS experience, and data/SaaS platform background.
- The job `date` was set to `2026-02-27` so the listing appears as a recent post and no other files were modified.

### Testing
- Ran `npm run lint` and the command completed successfully with a single unrelated lint warning in `pages/_app.tsx` about `<img>` usage that did not block the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21f4f4348832ab42042b53acd0fdb)